### PR TITLE
Fix 'out of sequence' javadoc error

### DIFF
--- a/src/main/java/org/kortforsyningen/proj/Proj.java
+++ b/src/main/java/org/kortforsyningen/proj/Proj.java
@@ -350,7 +350,7 @@ public final class Proj {
      * For large number of points, consider using coordinate tuples in {@code float[]} or {@code double[]}
      * arrays instead.
      *
-     * <h4>Serialization</h4>
+     * <h3>Serialization</h3>
      * The {@code DirectPosition} returned by this method is {@linkplain java.io.Serializable serializable},
      * but the CRS is lost in the serialization process because we do not serialize native PROJ objects.
      *


### PR DESCRIPTION
Running `mvn package` I get the following error:

```
$ mvn package
[INFO] Scanning for projects...
[INFO]
[INFO] ----------------------< org.kortforsyningen:proj >----------------------
[INFO] Building PROJ bindings 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ proj ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 2 resources
[INFO]
[INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ proj ---
[INFO] Compiling 3 source files to /Users/kevers/dev/PROJ-JNI/target/classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/kevers/dev/PROJ-JNI/src/main/java/org/kortforsyningen/proj/Proj.java:[353,8] header used out of sequence: <H4>
[INFO] 1 error
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.642 s
[INFO] Finished at: 2019-12-09T19:58:10+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project proj: Compilation failure
[ERROR] /Users/kevers/dev/PROJ-JNI/src/main/java/org/kortforsyningen/proj/Proj.java:[353,8] header used out of sequence: <H4>
[ERROR]
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```

This PR fixes the problem by changing to `<h3>` headers