### PR TITLE
Add initial build script for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,24 +20,18 @@ jobs:
         distribution: 'adopt'
     - name: Update apt-get
       run: sudo apt-get update
-    - name: Install sqlite3
-      run: sudo apt-get install sqlite3
+    - name: Install sqlite3 and build-essential
+      run: sudo apt-get install sqlite3 build-essential
     - name: Download PROJ
       run: wget https://download.osgeo.org/proj/proj-6.2.1.tar.gz
     - name: Extract PROJ source
       run: tar xf proj-6.2.1.tar.gz
-    - name: Enter PROJ directory
-      run: cd proj-6.2.1
-    - name: Autoconf PROJ
-      run: ./configure
-    - name: See number of processors
-      run: NPROC=$(nproc)
-    - name: Make PROJ
-      run: make -j${NPROC}
-    - name: Install PROJ
-      run: sudo make install
-    - name: Enter PROJ-JNI directory
-      run: cd ..
+    - name: Build and install PROJ
+      run: |
+        ./configure
+        make -j `nproc`
+        sudo make install
+      working-directory: ./proj-6.2.1
     - name: Build with Maven
       run: mvn package
     - name: List contents of directory


### PR DESCRIPTION
I don't currently have the ability to set up actions, but now that Travis is limiting free CI, it may be worth switching to GH actions sooner rather than later. This'll also be a useful way to avoid reworking more build scripts once it's time to start using dockcross etc or other alternatives when we're looking at building shaded jars for embedding native PROJ installs once we get to that stage.

@kbevers @desruisseaux 